### PR TITLE
各種APIに機能追加

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -823,7 +823,8 @@ export interface UploadVideoFileOption {
     subDirectory?: string; // 保存先サブディレクトリ
     viewName: string; // UI 上での表示名
     fileType: VideoFileType; // ファイルタイプ
-    file: File; // ファイル
+    file?: File; // ファイル
+    localFilePath?: string; // アップロードファイルのローカルパス 
 }
 
 /**

--- a/api.yml
+++ b/api.yml
@@ -1574,7 +1574,6 @@ components:
                 - parentDirectoryName
                 - viewName
                 - fileType
-                - file
             properties:
                 recordedId:
                     $ref: '#/components/schemas/RecordedId'
@@ -1592,6 +1591,9 @@ components:
                 file:
                     type: string
                     format: binary
+                localFilePath:
+                    description: アップロードファイルのローカルパス
+                    type: string
 
         Version:
             description: バージョン情報

--- a/client/src/model/api/video/VideoApiModel.ts
+++ b/client/src/model/api/video/VideoApiModel.ts
@@ -57,7 +57,12 @@ export default class VideoApiModel implements IVideoApiModel {
         }
         formData.append('viewName', option.viewName);
         formData.append('fileType', option.fileType);
-        formData.append('file', option.file);
+        if (typeof option.file !== 'undefined') {
+            formData.append('file', option.file);
+        }
+        if (typeof option.localFilePath !== 'undefined') {
+            formData.append('localFilePath', option.localFilePath);
+        }
 
         await this.repository.post('/videos/upload', formData, {
             headers: {

--- a/src/model/api/channel/ChannelApiModel.ts
+++ b/src/model/api/channel/ChannelApiModel.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from 'inversify';
 import mirakurun from 'mirakurun';
 import * as apid from '../../../../api';
+import Channel from '../../../db/entities/Channel';
 import IChannelDB from '../../db/IChannelDB';
 import IMirakurunClientModel from '../../IMirakurunClientModel';
 import IChannelApiModel, { IChannelApiModelError } from './IChannelApiModel';
@@ -20,10 +21,19 @@ class ChannelApiModel implements IChannelApiModel {
 
     /**
      * チャンネル情報取得
+     * @param channelId: apid.ChannelId
      * @return Promise<ChannelItem[]>
      */
-    public async getChannels(): Promise<apid.ChannelItem[]> {
-        const channels = await this.channelDB.findAll(true);
+    public async getChannels(channelId: apid.ChannelId): Promise<apid.ChannelItem[]> {
+        let channels: Channel[] = []
+        if (!channelId) {
+            channels = await this.channelDB.findAll(true);
+        } else {
+            const channel = await this.channelDB.findId(channelId);
+            if (channel) {
+                channels = [channel]
+            }
+        }
 
         return channels.map(c => {
             const result: apid.ChannelItem = {

--- a/src/model/api/channel/ChannelApiModel.ts
+++ b/src/model/api/channel/ChannelApiModel.ts
@@ -25,13 +25,13 @@ class ChannelApiModel implements IChannelApiModel {
      * @return Promise<ChannelItem[]>
      */
     public async getChannels(channelId: apid.ChannelId): Promise<apid.ChannelItem[]> {
-        let channels: Channel[] = []
+        let channels: Channel[] = [];
         if (!channelId) {
             channels = await this.channelDB.findAll(true);
         } else {
             const channel = await this.channelDB.findId(channelId);
             if (channel) {
-                channels = [channel]
+                channels = [channel];
             }
         }
 

--- a/src/model/api/channel/IChannelApiModel.ts
+++ b/src/model/api/channel/IChannelApiModel.ts
@@ -5,6 +5,6 @@ export namespace IChannelApiModelError {
 }
 
 export default interface IChannelApiModel {
-    getChannels(): Promise<apid.ChannelItem[]>;
+    getChannels(channelId: apid.ChannelId): Promise<apid.ChannelItem[]>;
     getLogo(channelId: apid.ChannelId): Promise<Buffer>;
 }

--- a/src/model/operator/recorded/IRecordedManageModel.ts
+++ b/src/model/operator/recorded/IRecordedManageModel.ts
@@ -17,8 +17,9 @@ export interface UploadedVideoFileOption {
     subDirectory?: string; // 保存先サブディレクトリ
     viewName: string; // UI 上での表示名
     fileType: apid.VideoFileType; // ファイルタイプ
-    fileName: string; // ファイル名
-    filePath: string; // ファイルパス (アップロード先)
+    fileName?: string; // ファイル名
+    filePath?: string; // ファイルパス (アップロード先)
+    localFilePath?: string; // アップロードファイルのローカルパス
 }
 
 export default interface IRecordedManageModel {

--- a/src/model/service/api/channels.ts
+++ b/src/model/service/api/channels.ts
@@ -3,11 +3,11 @@ import IChannelApiModel from '../../api/channel/IChannelApiModel';
 import container from '../../ModelContainer';
 import * as api from '../api';
 
-export const get: Operation = async (_req, res) => {
+export const get: Operation = async (req, res) => {
     const channelApiModel = container.get<IChannelApiModel>('IChannelApiModel');
 
     try {
-        api.responseJSON(res, 200, await channelApiModel.getChannels());
+        api.responseJSON(res, 200, await channelApiModel.getChannels(req.params.channelId));
     } catch (err: any) {
         api.responseServerError(res, err.message);
     }
@@ -17,6 +17,11 @@ get.apiDoc = {
     summary: '放送局情報取得',
     tags: ['channels'],
     description: '放送局情報を取得する',
+    parameters: [
+        {
+            $ref: '#/components/parameters/PathChannelId',
+        },
+    ],
     responses: {
         200: {
             description: '放送局情報を取得しました',

--- a/src/model/service/api/channels.ts
+++ b/src/model/service/api/channels.ts
@@ -7,7 +7,9 @@ export const get: Operation = async (req, res) => {
     const channelApiModel = container.get<IChannelApiModel>('IChannelApiModel');
 
     try {
-        api.responseJSON(res, 200, await channelApiModel.getChannels(req.params.channelId));
+        // クエリパラメータから channelId を取得
+        const channelId = parseInt(req.query.channelId as string, 10);
+        api.responseJSON(res, 200, await channelApiModel.getChannels(channelId));
     } catch (err: any) {
         api.responseServerError(res, err.message);
     }
@@ -19,7 +21,13 @@ get.apiDoc = {
     description: '放送局情報を取得する',
     parameters: [
         {
-            $ref: '#/components/parameters/PathChannelId',
+            name: 'channelId', // クエリパラメータの名前を指定
+            in: 'query', // パラメータの種類を指定
+            required: false, // 任意であることを指定
+            description: '放送局のID',
+            schema: {
+                type: 'integer', // データ型を指定
+            },
         },
     ],
     responses: {

--- a/src/model/service/api/videos/upload.ts
+++ b/src/model/service/api/videos/upload.ts
@@ -8,8 +8,8 @@ export const post: Operation = async (req, res) => {
     const recordedApiModel = container.get<IRecordedApiModel>('IRecordedApiModel');
 
     try {
-        if (typeof req.file === 'undefined') {
-            throw new Error('FileIsNotFound');
+        if (typeof req.file === 'undefined' && typeof req.body.localFilePath === 'undefined') {
+            throw new Error('FileIsNotFound OR localFilePathNotFound');
         }
 
         const option: UploadedVideoFileOption = {
@@ -17,8 +17,9 @@ export const post: Operation = async (req, res) => {
             parentDirectoryName: req.body.parentDirectoryName,
             viewName: req.body.viewName,
             fileType: req.body.fileType,
-            fileName: req.file.originalname,
-            filePath: req.file.path,
+            fileName: req.file ? req.file.originalname : undefined,
+            filePath: req.file ? req.file.path : undefined,
+            localFilePath: req.body.localFilePath,
         };
         if (typeof req.body.subDirectory !== 'undefined') {
             option.subDirectory = req.body.subDirectory;


### PR DESCRIPTION
## 概要(Summary)

- チャンネル取得APIにクエリを追加し、チャンネルIDをもとに1件返却可能に変更
- 録画ファイルアップロード機能にローカルパスの場合直接移動可能に変更
- サーバー起動時にconfig.ymlが存在しない場合は、テンプレートから自動コピーするように変更
